### PR TITLE
fix: change to be consistent with grist-core fee42ae

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ requirements:
 	cd core && yarn run install:python
 
 build:
-	cd core && yarn run build:prod
+	cd core && yarn run build
 
 start:
 	cd core && yarn start


### PR DESCRIPTION
<https://github.com/gristlabs/grist-core/commit/fee42ae90516b24482931bfcb4800280abd89feb>

This commit in grist-core have introduced a breaking change. `yarn build:prod` now builds without dev dependenies `yarn build` builds with dev dependencies